### PR TITLE
Feature#5/create conpany detail page

### DIFF
--- a/.$ER_job-search-manegement-app.drawio.bkp
+++ b/.$ER_job-search-manegement-app.drawio.bkp
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2023-11-14T05:18:04.089Z" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.0.3 Chrome/114.0.5735.289 Electron/25.8.4 Safari/537.36" etag="2u9NHPWKNeNEXZVGedZs" version="22.0.3" type="device">
+<mxfile host="Electron" modified="2023-11-16T17:03:52.627Z" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.2 Chrome/114.0.5735.289 Electron/25.9.4 Safari/537.36" etag="Uvl5uFvGvBE0A97zBpsK" version="22.1.2" type="device">
   <diagram id="R2lEEEUBdFMjLlhIrx00" name="Page-1">
-    <mxGraphModel dx="890" dy="452" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="#1b1d1e" math="0" shadow="0" extFonts="Permanent Marker^https://fonts.googleapis.com/css?family=Permanent+Marker">
+    <mxGraphModel dx="1020" dy="496" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="#1b1d1e" math="0" shadow="0" extFonts="Permanent Marker^https://fonts.googleapis.com/css?family=Permanent+Marker">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -164,7 +164,7 @@
           </mxGeometry>
         </mxCell>
         <mxCell id="vAT_HA_lvnV4tGosH2Bi-29" value="status BOOLEAN NOT NULL DEFAULT TRUE" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;labelBackgroundColor=none;rounded=1;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="1" vertex="1">
-          <mxGeometry x="70" y="270" width="370" height="30" as="geometry">
+          <mxGeometry x="65" y="240" width="370" height="30" as="geometry">
             <mxRectangle width="219.99999999999994" height="30" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
@@ -270,10 +270,8 @@
             <mxRectangle width="250" height="30" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="qNVb4q3aRCfNl3nhDVjc-1" value="user_mail VARCHAR(191) COLLATE utf8mb4_bin NOT NULL unique" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;labelBackgroundColor=none;rounded=1;strokeColor=#FFFFFF;fontColor=#FFFFFF;" vertex="1" parent="1">
-          <mxGeometry x="70" y="240" width="370" height="30" as="geometry">
-            <mxRectangle width="219.99999999999994" height="30" as="alternateBounds" />
-          </mxGeometry>
+        <mxCell id="xrDacTSOR659koXV6rhE-1" value="user / pass&lt;br&gt;root / dbpass" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+          <mxGeometry x="170" y="300" width="130" height="30" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/ER_job-search-manegement-app.drawio
+++ b/ER_job-search-manegement-app.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2023-11-16T17:03:52.627Z" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.2 Chrome/114.0.5735.289 Electron/25.9.4 Safari/537.36" etag="Uvl5uFvGvBE0A97zBpsK" version="22.1.2" type="device">
+<mxfile host="Electron" modified="2023-11-19T03:40:56.151Z" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.2 Chrome/114.0.5735.289 Electron/25.9.4 Safari/537.36" etag="H9lcSMOKYg_k_1F8c-Z0" version="22.1.2" type="device">
   <diagram id="R2lEEEUBdFMjLlhIrx00" name="Page-1">
-    <mxGraphModel dx="1020" dy="496" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="#1b1d1e" math="0" shadow="0" extFonts="Permanent Marker^https://fonts.googleapis.com/css?family=Permanent+Marker">
+    <mxGraphModel dx="713" dy="352" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" background="#1b1d1e" math="0" shadow="0" extFonts="Permanent Marker^https://fonts.googleapis.com/css?family=Permanent+Marker">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -54,48 +54,6 @@
           </mxGeometry>
         </mxCell>
         <mxCell id="C-vyLk0tnHw3VtMMgP7b-11" value="company_name char(64) NOT NULL" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-9" vertex="1">
-          <mxGeometry x="30" width="250" height="30" as="geometry">
-            <mxRectangle width="250" height="30" as="alternateBounds" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-13" value="detail" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;rounded=1;labelBackgroundColor=none;fillColor=#182E3E;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="1" vertex="1">
-          <mxGeometry x="520" y="480" width="280" height="240" as="geometry" />
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-14" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-13" vertex="1">
-          <mxGeometry y="30" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-15" value="PK" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-14" vertex="1">
-          <mxGeometry width="30" height="30" as="geometry">
-            <mxRectangle width="30" height="30" as="alternateBounds" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-16" value="detail_id int NOT NULL " style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-14" vertex="1">
-          <mxGeometry x="30" width="250" height="30" as="geometry">
-            <mxRectangle width="250" height="30" as="alternateBounds" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-17" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-13" vertex="1">
-          <mxGeometry y="60" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-18" value="FK1" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-17" vertex="1">
-          <mxGeometry width="30" height="30" as="geometry">
-            <mxRectangle width="30" height="30" as="alternateBounds" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-19" value="company_id int NOT NULL" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-17" vertex="1">
-          <mxGeometry x="30" width="250" height="30" as="geometry">
-            <mxRectangle width="250" height="30" as="alternateBounds" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-20" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-13" vertex="1">
-          <mxGeometry y="90" width="280" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-21" value="" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-20" vertex="1">
-          <mxGeometry width="30" height="30" as="geometry">
-            <mxRectangle width="30" height="30" as="alternateBounds" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="C-vyLk0tnHw3VtMMgP7b-22" value="detail_when TIMESTAMP NOT NULL" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-20" vertex="1">
           <mxGeometry x="30" width="250" height="30" as="geometry">
             <mxRectangle width="250" height="30" as="alternateBounds" />
           </mxGeometry>
@@ -181,25 +139,25 @@
           </mxGeometry>
         </mxCell>
         <mxCell id="cTWLPFwUOaLKqwMuq35s-3" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="1" vertex="1">
-          <mxGeometry x="530" y="580" width="280" height="30" as="geometry" />
+          <mxGeometry x="550" y="580" width="250" height="30" as="geometry" />
         </mxCell>
         <mxCell id="cTWLPFwUOaLKqwMuq35s-4" value="" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="cTWLPFwUOaLKqwMuq35s-3" vertex="1">
-          <mxGeometry width="30" height="30" as="geometry">
+          <mxGeometry width="26.78571428571429" height="30" as="geometry">
             <mxRectangle width="30" height="30" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
         <mxCell id="cTWLPFwUOaLKqwMuq35s-5" value="detail_subject char(32) NOT NULL" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="1" vertex="1">
-          <mxGeometry x="550" y="600" width="250" height="30" as="geometry">
+          <mxGeometry x="550" y="620" width="250" height="30" as="geometry">
             <mxRectangle width="250" height="30" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
         <mxCell id="cTWLPFwUOaLKqwMuq35s-6" value="detail_content char() NOT NULL" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="1" vertex="1">
-          <mxGeometry x="550" y="630" width="250" height="30" as="geometry">
+          <mxGeometry x="550" y="650" width="250" height="30" as="geometry">
             <mxRectangle width="250" height="30" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
         <mxCell id="cTWLPFwUOaLKqwMuq35s-7" value="detail_importance int default=0" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="1" vertex="1">
-          <mxGeometry x="550" y="660" width="250" height="30" as="geometry">
+          <mxGeometry x="550" y="680" width="250" height="30" as="geometry">
             <mxRectangle width="250" height="30" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
@@ -270,8 +228,60 @@
             <mxRectangle width="250" height="30" as="alternateBounds" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="xrDacTSOR659koXV6rhE-1" value="user / pass&lt;br&gt;root / dbpass" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+        <mxCell id="xrDacTSOR659koXV6rhE-1" value="user / pass&lt;br&gt;root / dbpass" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
           <mxGeometry x="170" y="300" width="130" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-13" value="detail" style="shape=table;startSize=30;container=1;collapsible=1;childLayout=tableLayout;fixedRows=1;rowLines=0;fontStyle=1;align=center;resizeLast=1;rounded=1;labelBackgroundColor=none;fillColor=#182E3E;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="1" vertex="1">
+          <mxGeometry x="520" y="470" width="280" height="240.00000000000023" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-14" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=1;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-13" vertex="1">
+          <mxGeometry y="30" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-15" value="PK" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;fontStyle=1;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-14" vertex="1">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-16" value="detail_id int NOT NULL " style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;fontStyle=5;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-14" vertex="1">
+          <mxGeometry x="30" width="250" height="30" as="geometry">
+            <mxRectangle width="250" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-17" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-13" vertex="1">
+          <mxGeometry y="60" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-18" value="FK1" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-17" vertex="1">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-19" value="user_id int NOT NULL" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-17" vertex="1">
+          <mxGeometry x="30" width="250" height="30" as="geometry">
+            <mxRectangle width="250" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-20" value="" style="shape=partialRectangle;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;top=0;left=0;right=0;bottom=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-13" vertex="1">
+          <mxGeometry y="90" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-21" value="" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-20" vertex="1">
+          <mxGeometry width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="C-vyLk0tnHw3VtMMgP7b-22" value="company_id int NOT NULL" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" parent="C-vyLk0tnHw3VtMMgP7b-20" vertex="1">
+          <mxGeometry x="30" width="250" height="30" as="geometry">
+            <mxRectangle width="250" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="MWxLnNuGUZn63tTdsskC-4" value="detail_when TIMESTAMP NOT NULL" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;align=left;spacingLeft=6;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" vertex="1" parent="1">
+          <mxGeometry x="550" y="590" width="250" height="30" as="geometry">
+            <mxRectangle width="250" height="30" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="MWxLnNuGUZn63tTdsskC-5" value="FK2" style="shape=partialRectangle;overflow=hidden;connectable=0;fillColor=none;top=0;left=0;bottom=0;right=0;rounded=1;labelBackgroundColor=none;strokeColor=#FFFFFF;fontColor=#FFFFFF;" vertex="1" parent="1">
+          <mxGeometry x="520" y="560" width="30" height="30" as="geometry">
+            <mxRectangle width="30" height="30" as="alternateBounds" />
+          </mxGeometry>
         </mxCell>
       </root>
     </mxGraphModel>

--- a/page_company.php
+++ b/page_company.php
@@ -43,8 +43,8 @@
                     // 掲示板システムのような表示方法
                     echo '<hr>';
                     echo '<div class="post">';
-                        echo ' "<p>"' . htmlspecialchars($value['id']) . '"</p>";';// 不必要な場合、削除
-                        echo '<h5>: "' . htmlspecialchars($value['detail_subject']) . '"</h5>';// タイトル、見出し
+                        // echo ' "<p>"' . htmlspecialchars($value['id']) . '"</p>";';// 不必要な場合、削除
+                        echo '<h5>' . htmlspecialchars($value['detail_subject']) . '</h5>';// タイトル、見出し
                         echo '<p class="post-text">' . htmlspecialchars($value['detail_content']) . '</p>';// 中身の表示
                         echo '<div class="container">';
                             echo "<p class='post-time'>イベント日時: " . htmlspecialchars($value['detail_when']) . "</p>";

--- a/page_company.php
+++ b/page_company.php
@@ -35,17 +35,17 @@
                 // イベントの追加
                 echo '<form action="page_update_company.php" method="POST">';
                 echo '<button type="submit" class="" name="trans_update_company">イベント追加</button>';
-                echo '<input type="huser_idden" name="user_user_id" value="'. htmlspecialchars($company_id, ENT_QUOTES, 'UTF-8') .'">';
+                echo '<input type="hidden" name="user_user_id" value="'. htmlspecialchars($company_id, ENT_QUOTES, 'UTF-8') .'">';
                 echo '</form>';
 
                 foreach($result as $value)
                 {
-                // 掲示板システムのような表示方法
-                echo '<hr>';
-                echo '<div class="post">';
-                    echo 'echo "<p>"' . htmlspecialchars($value['id']) . '"</p>";';// 不必要な場合、削除
-                    echo '<h5>: "' . htmlspecialchars($value['detail_subject']) . '"</h5>';// タイトル、見出し
-                    echo '<p class="post-text">' . htmlspecialchars($value['detail_content']) . '</p>';// 中身の表示
+                    // 掲示板システムのような表示方法
+                    echo '<hr>';
+                    echo '<div class="post">';
+                        echo ' "<p>"' . htmlspecialchars($value['id']) . '"</p>";';// 不必要な場合、削除
+                        echo '<h5>: "' . htmlspecialchars($value['detail_subject']) . '"</h5>';// タイトル、見出し
+                        echo '<p class="post-text">' . htmlspecialchars($value['detail_content']) . '</p>';// 中身の表示
                         echo '<div class="container">';
                             echo "<p class='post-time'>イベント日時: " . htmlspecialchars($value['detail_when']) . "</p>";
                             echo '<p class="importance">';
@@ -62,6 +62,7 @@
                                     break;
                                 case 3:
                                     echo '面接日';
+                                    break;
                             }
                             echo '</p>';
                         echo "</div>";

--- a/page_company.php
+++ b/page_company.php
@@ -1,0 +1,87 @@
+<?php
+    session_start();
+    $user_id = $_SESSION['user_id'];
+
+    if (isset($_GET['company_id'])) {
+        $_SESSION['company_id'] = $_GET['company_id'];
+    } else {
+        // エラー処理またはデフォルトの値をセットする場合
+        $_SESSION['company_id'] = null;
+    }
+    $company_id=$_SESSION['company_id'];
+
+    include 'header.php';
+    require_once 'dbconnect.php';
+
+    echo 'No.' . htmlspecialchars($company_id, ENT_QUOTES, 'UTF-8') . 'さんのエントリー企業';
+
+    try
+    {
+        $db = connect();
+        $sql = 'SELECT * FROM detail WHERE user_id=? AND company_id=?';
+        if($db)
+        {
+            $stmt = $db->prepare($sql);
+            $stmt->execute(array($user_id, $company_id));
+            $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
+            $stmt = null;
+            $db = null;
+
+            if($result !== false && $result !== null)
+            {
+                // ユーザuser_idに紐づけられた会社情報を表示
+                // (要修正)SQLでcompanyテーブルからidが一致するものを取り出し下の見出しに追加する
+                echo '<h1>情報</h1>';
+                // イベントの追加
+                echo '<form action="page_update_company.php" method="POST">';
+                echo '<button type="submit" class="" name="trans_update_company">イベント追加</button>';
+                echo '<input type="huser_idden" name="user_user_id" value="'. htmlspecialchars($company_id, ENT_QUOTES, 'UTF-8') .'">';
+                echo '</form>';
+
+                foreach($result as $value)
+                {
+                // 掲示板システムのような表示方法
+                echo '<hr>';
+                echo '<div class="post">';
+                    echo 'echo "<p>"' . htmlspecialchars($value['id']) . '"</p>";';// 不必要な場合、削除
+                    echo '<h5>: "' . htmlspecialchars($value['detail_subject']) . '"</h5>';// タイトル、見出し
+                    echo '<p class="post-text">' . htmlspecialchars($value['detail_content']) . '</p>';// 中身の表示
+                        echo '<div class="container">';
+                            echo "<p class='post-time'>イベント日時: " . htmlspecialchars($value['detail_when']) . "</p>";
+                            echo '<p class="importance">';
+                            switch ($value['detail_importance'])
+                            {
+                                case 0:
+                                    echo '';
+                                    break;
+                                case 1:
+                                    echo '重要';
+                                    break;
+                                case 2:
+                                    echo '締切日';
+                                    break;
+                                case 3:
+                                    echo '面接日';
+                            }
+                            echo '</p>';
+                        echo "</div>";
+                        // 編集ボタン
+                        echo '<a href="company.php" name="trans_company" value="">編集</a>';
+                    echo "</div>";
+                    echo "<hr>";
+                }
+            }
+            else
+            {
+                $err_msg = 'データが入っていません。';
+            }
+        }
+    }
+    catch(PDOException $e)
+    {
+        echo 'エラー: ' . htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8');
+        exit;
+    }
+
+    include 'footer.php';
+?>

--- a/page_company.php
+++ b/page_company.php
@@ -67,7 +67,7 @@
                             echo '</p>';
                         echo "</div>";
                         // 編集ボタン
-                        echo '<a href="company.php" name="trans_company" value="">編集</a>';
+                        echo '<a href="page_update_company.php" name="trans_company" value="">編集</a>';
                     echo "</div>";
                     echo "<hr>";
                 }

--- a/page_main.php
+++ b/page_main.php
@@ -31,47 +31,44 @@
 
                 // テーブル表示
                 echo '<table border="1">';
-                echo '<tr>';
-                echo '<th>No.</th>';
-                echo '<th>会社名</th>';
-                echo '<th>状態</th>';
-                echo '<th>リンク</th>';
-                echo '</tr>';
-                foreach($result as $value)
-                {
                     echo '<tr>';
-                    echo '<td>' . htmlspecialchars($value['company_id'], ENT_QUOTES, 'UTF-8') . '</td>';
-                    echo '<td>' . htmlspecialchars($value['company_name'], ENT_QUOTES, 'UTF-8') . '</td>';
-
-                    // 就活の状態を表示
-                    switch($value['company_status'])
-                    {
-                        case 0:
-                            echo '<td>落選</td>';
-                            break;
-                        case 1:
-                            echo '<td>エントリー前</td>';
-                            break;
-                        case 2:
-                            echo '<td>ES提出前</td>';
-                            break;
-                        case 3:
-                            echo '<td>面談前<td>';
-                            break;
-                        case 4:
-                            echo '<td>内定</td>';
-                            break;
-                    }
-
-                    // 各企業のぺージリンク
-                    $company_id = htmlspecialchars($value['company_status'], ENT_QUOTES, 'UTF-8');
-                    echo '<td>';
-                    echo '<a href="company.php" name="trans_company" value="">編集</a>';
-                    echo '</form>';
-                    echo "</td>";
-
+                        echo '<th>No.</th>';
+                        echo '<th>会社名</th>';
+                        echo '<th>状態</th>';
+                        echo '<th>リンク</th>';
                     echo '</tr>';
-                }
+                    foreach($result as $value)
+                    {
+                        echo '<tr>';
+                            echo '<td>' . htmlspecialchars($value['company_id'], ENT_QUOTES, 'UTF-8') . '</td>';
+                            echo '<td>' . htmlspecialchars($value['company_name'], ENT_QUOTES, 'UTF-8') . '</td>';
+
+                            // 就活の状態を表示
+                            switch($value['company_status'])
+                            {
+                                case 0:
+                                    echo '<td>落選</td>';
+                                    break;
+                                case 1:
+                                    echo '<td>エントリー前</td>';
+                                    break;
+                                case 2:
+                                    echo '<td>ES提出前</td>';
+                                    break;
+                                case 3:
+                                    echo '<td>面談前<td>';
+                                    break;
+                                case 4:
+                                    echo '<td>内定</td>';
+                                    break;
+                            }
+                        // 各企業のぺージリンク
+                        $company_id = htmlspecialchars($value['company_id'], ENT_QUOTES, 'UTF-8');
+                        echo '<td>';
+                        echo '<a href="page_company.php?company_id=' . $value['company_id'] . '" class="edit-link" name="trans_company" value="">編集</a>';
+                        echo "</td>";
+                    echo '</tr>';
+                    }
                 echo '</table>';
             }
             else
@@ -88,3 +85,30 @@
 
     include 'footer.php';
 ?>
+<script>
+    // 編集リンクがクリックされたときの処理
+    document.querySelectorAll('.edit-link').forEach(function(link) {
+        link.addEventListener('click', function(event) {
+            event.preventDefault(); // リンクのデフォルトの動作をキャンセル
+
+            // リンクのdata-company-id属性から会社IDを取得
+            var companyId = link.getAttribute('data-company-id');
+
+            // 会社IDをサーバーサイドに送信する（Ajaxを使用）
+            var xhr = new XMLHttpRequest();
+            xhr.open('POST', 'store_company_id.php', true);
+            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+            xhr.onload = function() {
+                // サーバーサイドでの処理が完了した後に実行されるコード
+                if (xhr.status === 200) {
+                    // 成功した場合の処理（任意の処理を追加）
+                    console.log('Company ID stored in session successfully.');
+                } else {
+                    // エラーが発生した場合の処理
+                    console.error('Error storing Company ID in session.');
+                }
+            };
+            xhr.send('company_id=' + companyId);
+        });
+    });
+</script>

--- a/page_main.php
+++ b/page_main.php
@@ -35,12 +35,15 @@
                 echo '<th>No.</th>';
                 echo '<th>会社名</th>';
                 echo '<th>状態</th>';
+                echo '<th>リンク</th>';
                 echo '</tr>';
                 foreach($result as $value)
                 {
                     echo '<tr>';
                     echo '<td>' . htmlspecialchars($value['company_id'], ENT_QUOTES, 'UTF-8') . '</td>';
                     echo '<td>' . htmlspecialchars($value['company_name'], ENT_QUOTES, 'UTF-8') . '</td>';
+
+                    // 就活の状態を表示
                     switch($value['company_status'])
                     {
                         case 0:
@@ -60,7 +63,13 @@
                             break;
                     }
 
-                    echo '<td>' . htmlspecialchars($value['company_status'], ENT_QUOTES, 'UTF-8') . '</td>';
+                    // 各企業のぺージリンク
+                    $company_id = htmlspecialchars($value['company_status'], ENT_QUOTES, 'UTF-8');
+                    echo '<td>';
+                    echo '<a href="company.php" name="trans_company" value="">編集</a>';
+                    echo '</form>';
+                    echo "</td>";
+
                     echo '</tr>';
                 }
                 echo '</table>';

--- a/page_update_company.php
+++ b/page_update_company.php
@@ -1,3 +1,84 @@
 <?php
+    // セッションスタート
+    session_start();
 
+    // セッションによる情報の引継ぎ
+    $user_id = $_SESSION['user_id'];
+    $company_id = $_SESSION['company_id'];
+
+    // データベース接続
+    require_once 'dbconnect.php';
+
+    if(isset($_SESSION['user_id']))
+    {
+        $id = $_SESSION['user_id'];
+
+        try
+        {
+            if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['trans_confirm_company']))
+            {
+                $db = connect();
+                $sql = 'INSERT INTO detail (user_id, company_id, detail_when, detail_subject, detail_content) VALUES (?, ?, ?, ?, ?)';
+
+                if($db)
+                {
+                    $stmt = $db->prepare($sql);
+
+                    // 変数の設定
+                    $detail_when = $_POST['detail_when'];
+                    $detail_subject = $_POST['detail_subject'];
+                    $detail_content = $_POST['detail_content'];
+
+                    $stmt->execute(array($user_id, $company_id, $detail_when, $detail_subject, $detail_content));
+                    $stmt = null;
+                    $db = null;
+
+                    // // セッション破棄
+                    // session_destroy();
+
+                    // セッション変数の削除
+                    unset($_SESSION['company_id']);
+
+                    header('Location: page_company.php?company_id='.$company_id);
+                    exit;
+                }
+            }
+        }
+        catch(PDOException $e)
+        {
+            echo $e->getMessage();
+            exit;
+        }
+    }
+    else
+    {
+        // ユーザーIDがセッションにない場合の処理（未ログインなど）
+        // ここに適切な処理を追加してください。
+        header('Location: login.php'); // 例：ログイン画面にリダイレクト
+        exit;
+    }
 ?>
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>イベント追加画面</title>
+    </head>
+    <body>
+        <h1>イベント追加</h1>
+        <form action="<?php echo $_SERVER['PHP_SELF']; ?>" method="POST">
+            イベント名<input type="text" name="detail_subject" value=""><br>
+            イベント内容<input type="text" name="detail_content" value=""><br>
+            日時<input type="date" name="detail_when" value=""><br>
+            <button type="submit" name="trans_confirm_company" value="">イベント追加</button>
+        </form>
+        <!-- フォームを使用してデータを送信 -->
+        <form id="backForm" action="page_company.php" method="GET">
+            <input type="hidden" name="user_id" value="<?php echo $user_id; ?>">
+            <input type="hidden" name="company_id" value="<?php echo $company_id; ?>">
+            <!-- 他の必要な隠し要素があればここに追加 -->
+            <a id="back" href="javascript:void(0);" onclick="document.getElementById('backForm').submit();">戻る</a>
+        </form>
+    </body>
+</html>


### PR DESCRIPTION
close:#5

## What?（変更の概要・何を変更したのか）

- 企業詳細ぺージの作成
- 選択された企業の経過を一覧できるようなぺージ
- 企業画面からメインページに戻る際は、すべてのセッションを削除、初期化を行う

## Why?（なぜ変更するのか）

- 一番このシステムの根幹部分になるコンテンツ
- これを継続していくことで、少しでも就活での情報整理がしやすいのでは

## How?（どう変更するのか）

- Dockerの起動
- WinSCPで起動したサーバへ転送
- phpファイルを記述
- ブランチ作成
- プルリクエスト作成
- SQLの構築
- sessionを使用しながらユーザidとcompany_idを継承する
- メインページに戻る際は、session_destroy()を行う
- メインページから遷移する際は、テーブルタグ内にリンクを作成し、クリックだけで遷移する
- 企業画面からメインページに戻る際は、すべてのセッションを削除、初期化を行う
- イベントの修正の場合、各修正ボタンからpage_update_companyへセッション情報を読み込みながら行い、イベントの新規作成の場合、nullでデータを送り、はじくようにする
- dateの入力で、何もなかった場合、現在時刻を入力させる

## Checklist

- [x] Dockerの起動
- [x] WinSCPで起動したサーバへ転送
- [x] phpファイルを記述
- [x] ブランチ作成
- [x] プルリクエスト作成
- [x] SQLの構築
- [x] sessionを使用しながらユーザidとcompany_idを継承する
- [x] メインページに戻る際は、session_destroy()を行う
- [x] メインページから遷移する際は、テーブルタグ内にリンクを作成し、クリックだけで遷移する
- [x] 企業画面からメインページに戻る際は、すべてのセッションを削除、初期化を行う
- [ ]  イベントの修正の場合、各修正ボタンからpage_update_companyへセッション情報を読み込みながら行い、イベントの新規作成の場合、nullでデータを送り、はじくようにする
- [ ] dateの入力で、何もなかった場合、現在時刻を入力させる